### PR TITLE
various fixes, and idiomatic Go

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     expose:
       - "3434"
     privileged: true
+    restart: always

--- a/notecard/Dockerfile.aarch64
+++ b/notecard/Dockerfile.aarch64
@@ -3,8 +3,7 @@ FROM balenalib/aarch64-alpine-golang:3.18-build as builder
 WORKDIR /usr/src/app
 COPY . ./
 
-RUN go install && \
-    go build -o bin/notecard
+RUN go build -o bin/notecard
 
 FROM balenalib/aarch64-alpine:3.18-run as runner
 

--- a/notecard/Dockerfile.amd64
+++ b/notecard/Dockerfile.amd64
@@ -3,8 +3,7 @@ FROM balenalib/amd64-alpine-golang:3.18-build as builder
 WORKDIR /usr/src/app
 COPY . ./
 
-RUN go install && \
-    go build -o bin/notecard
+RUN go build -o bin/notecard
 
 FROM balenalib/amd64-alpine:3.18-run as runner
 

--- a/notecard/Dockerfile.armv7hf
+++ b/notecard/Dockerfile.armv7hf
@@ -3,8 +3,7 @@ FROM balenalib/armv7hf-alpine-golang:3.18-build as builder
 WORKDIR /usr/src/app
 COPY . ./
 
-RUN go install && \
-    go build -o bin/notecard
+RUN go build -o bin/notecard
 
 FROM balenalib/armv7hf-alpine:3.18-run as runner
 

--- a/notecard/Dockerfile.template
+++ b/notecard/Dockerfile.template
@@ -3,8 +3,7 @@ FROM balenalib/%%BALENA_ARCH%%-alpine-golang:3.18-build as builder
 WORKDIR /usr/src/app
 COPY . ./
 
-RUN go install && \
-    go build -o bin/notecard
+RUN go build -o bin/notecard
 
 FROM balenalib/%%BALENA_ARCH%%-alpine:3.18-run as runner
 

--- a/notecard/main.go
+++ b/notecard/main.go
@@ -65,7 +65,6 @@ func (s *server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	note_rsp_json, err := json.Marshal(note_rsp)
 	if err != nil {
-		fmt.Println("Error encoding JSON:", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Printf("while encoding transaction response: %v", err)
 		return
@@ -86,14 +85,14 @@ func setupNotecard(protocol string) (*notecard.Context, error) {
 	if protocol == Serial {
 		card, err := notecard.OpenSerial("/dev/tty.usbmodemNOTE1", 9600)
 		if err != nil {
-			return nil, fmt.Errorf("Error opening Notecard: %v", err)
+			return nil, fmt.Errorf("error opening Notecard: %v", err)
 		}
 		return card, nil
 	}
 
 	card, err := notecard.OpenI2C("/dev/i2c-1", 0x17)
 	if err != nil {
-		return nil, fmt.Errorf("Error opening Notecard: %v", err)
+		return nil, fmt.Errorf("error opening Notecard: %v", err)
 	}
 	return card, nil
 }


### PR DESCRIPTION
probably the most important fix: the request body was never getting closed. AFAIR that leads to resource leaking (mem or file handlers, don't recall for sure).

also changed the error handling in the http server. in general, as a matter of security, you don't want to serve too much of the diagnostic to the client. So you log it for yourself, but you don't serve the details of the error.

also you usually only want to panic in rare cases: when you're debugging, or want you want to bring attention to yourself the dev that something that should never ever really happen happened (and you probably don't even want to do that on long lived entities like an HTTP server, that should always be up). But if the logging I added instead is not enough for you, we can of course revisit that.

we were JSON decoding, and JSON reencoding, the request body for no reason that I could see. so I removed that. And I think we can even do better, see my TODO in the code.

using a global var for the card context was ok in that case, but I still made it a bit more Go idiomatic, by making it part of a struct that implements ServeHTTP instead.

also note, you can't (well, you can, but it's useless) do a WriteHeader after a Write. Because as soon as you call Write, the response (and hence the header) has already been sent (with an implicit call to WriteHeader).

other than that, various cleanups to make it more Go idiomatic :)

it builds on balena, but I haven't been able to actually test it oc.